### PR TITLE
[feat] Toggle tiling per desktop

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -665,6 +665,7 @@ function Layout ()
 
 var tiledClients = {}; // windowId of added clients
 var floatingClients = {}; // windowId of floating clients
+var floatingDesktops = {}; // ids of desktops where tiling is disabled
 var layout = new Layout(); // main class, contains all methods
 
 // --------------
@@ -907,7 +908,7 @@ var Client =
 workspace.clientActivated.connect (function (client) // clientAdded does not work for a lot of clients
 {
   if (client === null || floatingClients.hasOwnProperty(client.windowId)) {return -1;}
-  if (!Parameters.enabled) {return Client.float(client);}
+  if (Parameters.enabled === floatingDesktops.hasOwnProperty(Converter.currentIndex())) {return Client.float(client);}
   return Client.tile(client); // validate does floating already, do not check here and float on fail
 });
 
@@ -1102,20 +1103,23 @@ registerShortcut ('Grid-Tiling: Tile/Float', 'Grid-Tiling: Tile/Float', 'Meta+T'
 
 registerShortcut ('Grid-Tiling: Toggle Tile/Float Current Desktop', 'Grid-Tiling: Toggle Tile/Float Current Desktop', 'Meta+Shift+T', function ()
 {
-  Parameters.enabled = !Parameters.enabled;
+  var different;
+  if (floatingDesktops.hasOwnProperty(Converter.currentIndex())) {
+    delete floatingDesktops[Converter.currentIndex()];
+    different = false;
+  } else {
+    floatingDesktops[Converter.currentIndex()] = true;
+    different = true;
+  }
 
   var clients = workspace.clientList();
-  if (Parameters.enabled) {
-    for (var i = 0; i < clients.length; i++)
-    {
-      if (clients[i] === null || clients[i].desktop !== workspace.currentDesktop) {continue;}
-      Client.tile(clients[i]);
-    }
-  } else {
-    for (var i = 0; i < clients.length; i++)
-    {
-      if (clients[i] === null || clients[i].desktop !== workspace.currentDesktop || floatingClients.hasOwnProperty(clients[i].windowId)) {continue;}
+  for (var i = 0; i < clients.length; i++)
+  {
+    if (clients[i] === null || clients[i].desktop !== workspace.currentDesktop) {continue;}
+    if (Parameters.enabled === different) {
       Client.float(clients[i]);
+    } else {
+      Client.tile(clients[i]);
     }
   }
 

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -59,6 +59,7 @@ var Parameters =
   dividerBounds: Number(readConfig('dividerBounds', 0.3)),
   dividerStepSize: Number(readConfig('dividerStepSize', 0.05)),
   border: Algorithm.toBool(readConfig('border', false)),
+  enabled: readConfig('startEnabled', true),
   margin:
   {
     top: Number(readConfig('topMargin', 0)),
@@ -906,6 +907,7 @@ var Client =
 workspace.clientActivated.connect (function (client) // clientAdded does not work for a lot of clients
 {
   if (client === null || floatingClients.hasOwnProperty(client.windowId)) {return -1;}
+  if (!Parameters.enabled) {return Client.float(client);}
   return Client.tile(client); // validate does floating already, do not check here and float on fail
 });
 
@@ -1096,6 +1098,28 @@ registerShortcut ('Grid-Tiling: Tile/Float', 'Grid-Tiling: Tile/Float', 'Meta+T'
     return Client.float(client);
   }
   return -1;
+});
+
+registerShortcut ('Grid-Tiling: Toggle Tile/Float Current Desktop', 'Grid-Tiling: Toggle Tile/Float Current Desktop', 'Meta+Shift+T', function ()
+{
+  Parameters.enabled = !Parameters.enabled;
+
+  var clients = workspace.clientList();
+  if (Parameters.enabled) {
+    for (var i = 0; i < clients.length; i++)
+    {
+      if (clients[i] === null || clients[i].desktop !== workspace.currentDesktop) {continue;}
+      Client.tile(clients[i]);
+    }
+  } else {
+    for (var i = 0; i < clients.length; i++)
+    {
+      if (clients[i] === null || clients[i].desktop !== workspace.currentDesktop || floatingClients.hasOwnProperty(clients[i].windowId)) {continue;}
+      Client.float(clients[i]);
+    }
+  }
+
+  return layout.render();
 });
 
 registerShortcut ('Grid-Tiling: Close Desktop', 'Grid-Tiling: Close Desktop', 'Meta+Q', function ()

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -59,7 +59,7 @@ var Parameters =
   dividerBounds: Number(readConfig('dividerBounds', 0.3)),
   dividerStepSize: Number(readConfig('dividerStepSize', 0.05)),
   border: Algorithm.toBool(readConfig('border', false)),
-  enabled: readConfig('startEnabled', true),
+  enabled: (readConfig('startEnabled', true) === true),
   margin:
   {
     top: Number(readConfig('topMargin', 0)),

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -69,5 +69,9 @@
         <label>floating captions</label>
         <default></default>
       </entry>
+      <entry name="startEnabled" type="bool">
+          <label>Enable tiling at start</label>
+          <default>true</default>
+      </entry>
     </group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -438,6 +438,20 @@
       </item>
      </layout>
     </item>
+    <item>
+     <widget class="Line" name="lineDivider5">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="kcfg_startEnabled">
+      <property name="text">
+       <string>Enable tiling at start</string>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
  </widget>


### PR DESCRIPTION
Close #45

- Add a shortcut for enabling/disabling tiling on the current desktop (default `Meta+Shift+T`)
  - Either sets all tiled windows to float or tiles all floating windows.
  - Follows ignore rules - reuses Client methods
- Add a setting to start the script with tiling disabled - need to enable it manually per desktop
  - Internal name: `<bool> startEnabled`
  - Default: `true`

---

![Screenshot_20200114_185446](https://user-images.githubusercontent.com/24496417/72369525-a1a9aa00-3700-11ea-9bc7-fd060570063c.png)
